### PR TITLE
Add args custom parser for double vectors

### DIFF
--- a/apps/gmmPointSetRegistration.cxx
+++ b/apps/gmmPointSetRegistration.cxx
@@ -12,6 +12,7 @@
 #include "itkPointSetToPointSetMetrics.h"
 
 #include "args.hxx"
+#include "argsCustomParsers.h"
 
 #include "agtkIO.h"
 #include "agtkCommandIterationUpdate.h"
@@ -30,7 +31,7 @@ int main(int argc, char** argv) {
 
   args::ValueFlag<std::string> argFixedFileName(allRequired, "fixed", "The fixed mesh filename", {'f', "fixed"});
   args::ValueFlag<std::string> argMovingFileName(allRequired, "moving", "The moving mesh filename", {'m', "moving"});
-  args::ValueFlagList<float> argScale(allRequired, "scale", "The scale levels", {'s', "scale"});
+  args::ValueFlag<std::vector<double>, args::DoubleVectorReader> argScale(allRequired, "scale", "The scale levels", {'s', "scale"});
   
   args::ValueFlag<std::string> argOutputFileName(parser, "output", "The output mesh filename", {'o', "output"});
   args::ValueFlag<unsigned int> argNumberOfIterations(parser, "iterations", "The number of iterations", {'i', "iterations"});
@@ -59,7 +60,7 @@ int main(int argc, char** argv) {
 
   std::string fixedFileName = args::get(argFixedFileName);
   std::string movingFileName = args::get(argMovingFileName);
-  std::vector<float> scale = args::get(argScale);
+  std::vector<double> scale = args::get(argScale);
   
   unsigned int numberOfIterations = 100;
 

--- a/apps/gmmTransformMesh.cxx
+++ b/apps/gmmTransformMesh.cxx
@@ -3,6 +3,7 @@
 #include <itkTransformMeshFilter.h>
 
 #include "args.hxx"
+#include "argsCustomParsers.h"
 #include "agtkIO.h"
 
 typedef itk::Mesh<float, 3U> MeshType;
@@ -17,7 +18,7 @@ int main(int argc, char** argv) {
 
   args::ValueFlag<std::string> argInputFile(allRequired, "input", "The input mesh filename", {'i', "input"});
   args::ValueFlag<std::string> argOutputFile(allRequired, "output", "The output mesh filename", {'o', "output"});
-  args::ValueFlagList<double> argTransform(allRequired, "transform", "The transform vector", {'t', "transform"});
+  args::ValueFlag<std::vector<double>, args::DoubleVectorReader> argTransform(allRequired, "transform", "The transform vector", {'t', "transform"});
 
   try {
     parser.ParseCLI(argc, argv);

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ project(${_name})
 set(HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/agtkIO.h
     ${CMAKE_CURRENT_SOURCE_DIR}/agtkCommandIterationUpdate.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/argsCustomParsers.h
 )
 
 add_library(${_name} INTERFACE)

--- a/utils/argsCustomParsers.h
+++ b/utils/argsCustomParsers.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iterator>
+#include <iostream>
+
+#include "args.hxx"
+
+
+namespace args
+{
+
+template<typename Out>
+void split(const std::string &s, char delim, Out result)
+{
+  std::stringstream ss;
+  ss.str(s);
+  std::string item;
+
+  while (std::getline(ss, item, delim)) {
+    if (!item.empty()) {
+      *(result++) = item;
+    }
+  }
+}
+
+std::vector<std::string> split(const std::string &s, char delim)
+{
+  std::vector<std::string> elems;
+  split(s, delim, std::back_inserter(elems));
+  return elems;
+}
+
+struct DoubleVectorReader
+{
+  void operator()(const std::string &name, const std::string &value, std::vector<double> &destination)
+  {
+    destination.clear();
+
+    std::vector<std::string> elems = split(value, ' ');
+
+    try {
+      for (const std::string &elem : elems) {
+        destination.push_back(std::stod(elem));
+      }
+    }
+    catch (const std::invalid_argument &err) {
+      throw args::ParseError(err.what());
+    }
+  }
+};
+
+}  // args

--- a/utils/argsCustomParsers.h
+++ b/utils/argsCustomParsers.h
@@ -4,7 +4,6 @@
 #include <sstream>
 #include <vector>
 #include <iterator>
-#include <iostream>
 
 #include "args.hxx"
 


### PR DESCRIPTION
Now we can set a double vector argument as `-v "1.0 2.2 3.5"` instead `-v 1.0 -v 2.2 -v 3.5`